### PR TITLE
check value encoding and parse object for return

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,10 @@ module.exports = function(db, opts) {
         res.statusCode = err.notFound ? 404 : 500;
         return res.end(err.message);
       }
+
+      if (db.options.valueEncoding == 'json' && typeof(value) == "object")
+        value = JSON.stringify(value);
+
       res.statusCode = 200;
       !!value ? res.end(value) : res.end('\0');
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "levelweb",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "LevelDB over http or https.",
   "main": "index.js",
   "scripts": {
@@ -17,6 +17,13 @@
     "server"
   ],
   "author": "hij1nx",
+  "contributors": [
+    {
+      "name": "Erik Kristensen",
+      "email": "erik@erikkristensen.com",
+      "url": "https://github.com/ekristen"
+    }
+  ],
   "license": "ISC",
   "dependencies": {
     "paramify": "^0.1.2",

--- a/test.js
+++ b/test.js
@@ -28,7 +28,8 @@ test('test api', function(t) {
         { type: 'put', key: 'test5key', value: 'test5value' },
         { type: 'put', key: 'test6key', value: 'test6value' },
         { type: 'put', key: 'test7key', value: 'test7value' },
-        { type: 'put', key: 'test8key', value: 'test8value' }
+        { type: 'put', key: 'test8key', value: 'test8value' },
+        { type: 'put', key: 'test10key', value: { some: 'json'} }
       ],
       function(err) {
         t.ok(!err);
@@ -62,7 +63,7 @@ test('test api', function(t) {
     req.end();
   });
 
-  test('GET', function(t) {
+  test('GET STRING', function(t) {
 
     var r = xtend(options, { method: 'GET', path: '/test1key' });
     var req = http.request(r, function(res) {
@@ -80,6 +81,24 @@ test('test api', function(t) {
     });
     req.end();
   });
+  
+  test('GET JSON', function(t) {
+    var r = xtend(options, { method: 'GET', path: '/test10key' });
+    var req = http.request(r, function(res) {
+
+      t.equal(res.statusCode, 200);
+
+      res.on('data', function(value) {
+        t.equal(value.toString(), JSON.stringify({some: 'json'}));
+        t.end();
+      });
+    });
+
+    req.on('error', function(e) {
+      t.fail(e);
+    });
+    req.end();
+  })
 
   test('DELETE', function(t) {
 


### PR DESCRIPTION
There exists a bug, that if valueEncoding is `json` that the object does not get parsed and throws an error when trying to return a non Buffer or string through the http server. This resolves that problem. 

Added unit tests to cover.